### PR TITLE
Made shader materials unique.

### DIFF
--- a/addons/post_processing/node/post_process.gd
+++ b/addons/post_processing/node/post_process.gd
@@ -143,7 +143,6 @@ func _enter_tree():
 	_update_shaders() 
 
 func _add_canvas_layer_children(_path : String, _name: String) -> void:
-	func _add_canvas_layer_children(_path : String, _name: String) -> void:
 	var child_instance = load(_path).instantiate()
 	add_child(child_instance)
 	var material_instance = child_instance.get_children()[0].material.duplicate()

--- a/addons/post_processing/node/post_process.gd
+++ b/addons/post_processing/node/post_process.gd
@@ -143,8 +143,12 @@ func _enter_tree():
 	_update_shaders() 
 
 func _add_canvas_layer_children(_path : String, _name: String) -> void:
-	add_child(load(_path).instantiate())
-	print_debug("Successfully added child canvas-layer: " + _name + " to PostProcess adddon node.")
+	func _add_canvas_layer_children(_path : String, _name: String) -> void:
+	var child_instance = load(_path).instantiate()
+	add_child(child_instance)
+	var material_instance = child_instance.get_children()[0].material.duplicate()
+	child_instance.get_children()[0].material = material_instance
+	print_debug("Successfully added child canvas-layer: " + _name + " to PostProcess addon node.")
 
 func _process(delta):
 	if not configuration:


### PR DESCRIPTION
I noticed that different objects with a postprocessing node shared the same shader materials regardless of one objects configs, the proposed change makes each material unique allowing for different configurations of the same shader.

![ss](https://github.com/ItsKorin/Godot-Post-Process-Plugin/assets/79162124/7bbc2c69-24ea-4f79-a02c-77a38ec90c64)
