### PR TITLE
Make dynamic update calls work and small bugfix

### DIFF
--- a/addons/post_processing/node/children/ChromaticAberration.tscn
+++ b/addons/post_processing/node/children/ChromaticAberration.tscn
@@ -7,6 +7,7 @@ shader = ExtResource("1_qxjen")
 shader_parameter/offset = 5.23
 
 [node name="ChromaticAberration" type="CanvasLayer"]
+visible = false
 layer = 102
 
 [node name="data" type="ColorRect" parent="."]

--- a/addons/post_processing/node/post_process.gd
+++ b/addons/post_processing/node/post_process.gd
@@ -3,6 +3,7 @@ extends CanvasLayer
 
 @export_category("Post Process")
 @export var configuration : PostProcessingConfiguration
+@export var dynamically_update : bool = true
 
 func update_shaders() -> void:
 	if not configuration:
@@ -151,7 +152,10 @@ func _add_canvas_layer_children(_path : String, _name: String) -> void:
 func _process(delta):
 	if not configuration:
 		return
-	if Engine.is_editor_hint() or !Engine.is_editor_hint():
-		if configuration.reload == true:
-			update_shaders()
-			configuration.reload = false
+	if Engine.is_editor_hint():
+		return
+	if not dynamically_update:
+		return
+	if configuration.reload:
+		update_shaders()
+		configuration.reload = false

--- a/addons/post_processing/node/post_process.gd
+++ b/addons/post_processing/node/post_process.gd
@@ -4,7 +4,7 @@ extends CanvasLayer
 @export_category("Post Process")
 @export var configuration : PostProcessingConfiguration
 
-func _update_shaders() -> void:
+func update_shaders() -> void:
 	if not configuration:
 		return
 	for child in get_children():
@@ -139,7 +139,7 @@ func _enter_tree():
 	_add_canvas_layer_children("res://addons/post_processing/node/children/ascii.tscn", "ASCII")
 	_add_canvas_layer_children("res://addons/post_processing/node/children/CRT.tscn", "CRT")
 	
-	_update_shaders() 
+	update_shaders()
 
 func _add_canvas_layer_children(_path : String, _name: String) -> void:
 	var child_instance = load(_path).instantiate()
@@ -153,5 +153,5 @@ func _process(delta):
 		return
 	if Engine.is_editor_hint() or !Engine.is_editor_hint():
 		if configuration.reload == true:
-			_update_shaders()
+			update_shaders()
 			configuration.reload = false


### PR DESCRIPTION
Hi Korin,

In my project I dynamically add an entire instance of a postprocessingconfig resource to the node dynamically, so I figured it would be more efficient to make the "update shaders" function by default public, so I could call it instead of flipping the toggle to force update. 

Looking at @SAED2906 's addition of set functions, I added a by-default TRUE variable to the main node to enable/disable loading these values dynamically. The "enter scene tree" call to the function isn't touched so disabling this code shouldn't impact loading. Hope this is an OK compromise for you both. If not, happy to remove it, as it doesn't change anything in my project.

The chromatic abberation filter was also the only one that wasn't hidden by default which is important doing things the way I have as the absence of any config (I think) should default to any config being applied, the chromatic abberation was the only one which had that default visibility.

I also removed the positive is_editor_hint() case as mentioned in my issue #12 but am open if there's something I missed here.

Thanks guys.