### PR TITLE
Fix duplicate instances of effects

### DIFF
--- a/addons/post_processing/node/post_process.gd
+++ b/addons/post_processing/node/post_process.gd
@@ -137,8 +137,7 @@ func _check_shader_visibility(_name: String) -> bool:
 		push_error("#Undefined type Post Processing addon - verify it has been properly integrated.")
 		return false # bad!
 
-func _enter_tree():
-	
+func _ready():
 	_add_canvas_layer_children("res://addons/post_processing/node/children/ChromaticAberration.tscn", "CA")
 	_add_canvas_layer_children("res://addons/post_processing/node/children/blur.tscn", "BL")
 	_add_canvas_layer_children("res://addons/post_processing/node/children/fish_eye.tscn", "FEYE")
@@ -155,7 +154,10 @@ func _enter_tree():
 	_add_canvas_layer_children("res://addons/post_processing/node/children/color_correction.tscn", "CC")
 	_add_canvas_layer_children("res://addons/post_processing/node/children/pixelate.tscn", "PXL")
 	_add_canvas_layer_children("res://addons/post_processing/node/children/palette.tscn", "PLT")
-	
+
+	update_shaders()
+
+func _enter_tree():
 	update_shaders()
 
 func _add_canvas_layer_children(_path : String, _name: String) -> void:


### PR DESCRIPTION
Duplicate instances of effects can occur because `_enter_tree` can be called more than once. New children with the same name are renamed resulting in the `#Undefined type Post Processing addon` error. Moved effect instantiation to `_ready` which only gets called once.

Fixes
- #6 