### PR TITLE
Simplify process loop

### DIFF
--- a/addons/post_processing/node/post_process.gd
+++ b/addons/post_processing/node/post_process.gd
@@ -170,7 +170,6 @@ func _add_canvas_layer_children(_path : String, _name: String) -> void:
 func _process(delta):
 	if not configuration:
 		return
-	if Engine.is_editor_hint():
 	if configuration.reload and (dynamically_update or Engine.is_editor_hint()):
 		configuration.reload = false
 		update_shaders()

--- a/addons/post_processing/node/post_process.gd
+++ b/addons/post_processing/node/post_process.gd
@@ -171,14 +171,6 @@ func _process(delta):
 	if not configuration:
 		return
 	if Engine.is_editor_hint():
-		if dynamically_update:
-			update_shaders()
-		else:
-			if configuration.reload:
-				configuration.reload = false
-				update_shaders()
-	else:
-		update_shaders()
-	if configuration.reload:
+	if configuration.reload and (dynamically_update or Engine.is_editor_hint()):
 		configuration.reload = false
 		update_shaders()


### PR DESCRIPTION
Hi Korin, others,

I was experiencing some issues with my implementation of the post addon and while reviewing the code I gave the process function loop some thought again. I still didn't fully grok the intention with it, so I rewrote it as such. I'm not sure if this is the correct approach, I'd welcome anyone's input.

**Here are my thoughts:**
Regenerate the shaders (update_shaders() call) only in the following cases:

1. When the function is called manually.
2. When the values have been changed, provoking a change in the configuration.reload flag WHILE in the editor (experimenting) via Editor.is_editor_hint().
3. When the values have been changed, provoking a change in the configuration.reload flag WHILE ingame for those people who have set dynamically_update to true. 

I can't think of any other cases and the logic felt fuzzy with the nesting. Does this make sense to everyone else? 