### PR TITLE
Define a class name for the plugin

### DIFF
--- a/addons/post_processing/node/post_process.gd
+++ b/addons/post_processing/node/post_process.gd
@@ -1,5 +1,6 @@
 @tool
 extends CanvasLayer
+class_name PostProcess
 
 @export_category("Post Process")
 @export var configuration : PostProcessingConfiguration


### PR DESCRIPTION
Simple change - just to add a class_name to the add-on (like many others have) to allow dynamic adding via code.