### PR TITLE
Store instantiated canvas layers in dictionary keyed to an enum

### DIFF
--- a/addons/post_processing/node/post_process.gd
+++ b/addons/post_processing/node/post_process.gd
@@ -2,73 +2,98 @@
 extends CanvasLayer
 class_name PostProcess
 
+enum EffectType {
+	ANALOG_MONITOR,
+	ASCII,
+	BLUR,
+	CHROMATIC_ABERRATION,
+	CIRCULAR_WAVES,
+	COLOR_CORRECTION,
+	CRT,
+	FISHEYE,
+	GLITCH,
+	GRAIN,
+	OUTLINE,
+	PALETTE,
+	PIXELATE,
+	SCREEN_SHAKE,
+	SPEED_LINES,
+	VIGNETTE,
+}
+
+## Stores the instantiated color rect of an effect keyed to its EffectType
+var effects: Dictionary = {}
+
 @export_category("Post Process")
 @export var configuration : PostProcessingConfiguration
 @export var dynamically_update : bool = true
 
+
 func update_shaders() -> void:
 	if not configuration:
 		return
-	for child in get_children():
-		var data : ColorRect = child.get_child(0)
-		if data:
-			_update_shader_parameters(child.name, data.material)
-		child.visible = _check_shader_visibility(child.name)
-	return
+	for e in effects:
+		var effect_canvas = effects[e]
+		if effect_canvas:
+			var effect_rect: ColorRect = effect_canvas.get_child(0)
+			if effect_rect:
+				_update_shader_parameters(e, effect_rect.material)
+				effect_canvas.visible = _check_shader_visibility(e)
 
-func _update_shader_parameters( _name : String, _material : Material) -> void:
-	match _name:
-		"Palette":
+
+func _update_shader_parameters( _type : EffectType, _material : Material) -> void:
+	match _type:
+		EffectType.PALETTE:
 			_material.set_shader_parameter("palette", configuration.PalettePalette)
-		"Pixelate":
+		EffectType.PIXELATE:
 			_material.set_shader_parameter("pixelSize", configuration.PixelatePixelSize)
-		"ColorCorrection":
+		EffectType.COLOR_CORRECTION:
 			_material.set_shader_parameter("tint", configuration.ColorCorrectionTint)
 			_material.set_shader_parameter("brightness", configuration.ColorCorrectionBrightness)
 			_material.set_shader_parameter("saturation", configuration.ColorCorrectionSaturation)
-		"ChromaticAberration":
+		EffectType.CHROMATIC_ABERRATION:
 			_material.set_shader_parameter("offset", configuration.StrenghtCA)
-		"Blur":
+		EffectType.BLUR:
 			_material.set_shader_parameter("lod", configuration.L_O_D)
-		"FishEye":
+		EffectType.FISHEYE:
 			_material.set_shader_parameter("aspect", configuration.FishEyeAspect)
 			_material.set_shader_parameter("distortion", configuration.FishEyeDistortion)
 			_material.set_shader_parameter("radius", configuration.FishEyeRadius)
 			_material.set_shader_parameter("alpha", configuration.FishEyeAlpha)
 			_material.set_shader_parameter("crop", configuration.FishEyeCrop)
 			_material.set_shader_parameter("crop_color", configuration.FishEyeCropColor)
-		"Vignette":
+		EffectType.VIGNETTE:
 			_material.set_shader_parameter("vignette_intensity", configuration.VignetteIntensity)
 			_material.set_shader_parameter("vignette_opacity", configuration.VignetteOpacity)
 			_material.set_shader_parameter("vignette_rgb", configuration.VignetteR_G_B)
-		"Glitch":
+		EffectType.GLITCH:
 			_material.set_shader_parameter("range", configuration.GlitchRange)
 			_material.set_shader_parameter("noiseQuality", configuration.GlitchNoiseQuality)
 			_material.set_shader_parameter("noiseIntensity", configuration.GlitchIntenity)
 			_material.set_shader_parameter("offsetIntensity", configuration.GlitchOffset)
 			_material.set_shader_parameter("colorOffsetIntensity", configuration.GlitchColorOffset)
-		"Outline":
+		EffectType.OUTLINE:
 			_material.set_shader_parameter("edge_color", configuration.OutlineColor)
 			_material.set_shader_parameter("threshold", configuration.OutlineThreshold)
 			_material.set_shader_parameter("blend", configuration.OutlineBlend)
-		"ScreenShake":
+		EffectType.SCREEN_SHAKE:
 			_material.set_shader_parameter("ShakeStrength", configuration.ScreenShakePower)
-		"AnalogMonitor":
+		EffectType.ANALOG_MONITOR:
 			_material.set_shader_parameter("res", configuration.AnalogMonitorResolution)
-		"Grain":
+		EffectType.GRAIN:
 			_material.set_shader_parameter("strength", configuration.GrainPower)
-		"CircularWaves":
+		EffectType.CIRCULAR_WAVES:
 			_material.set_shader_parameter("amplitude", configuration.CircularWavesAmplitude)
 			_material.set_shader_parameter("frequency", configuration.CircularWavesFrequency)
 			_material.set_shader_parameter("rippleRate", configuration.CircularWavesRippleRate)
-		"SpeedLines":
+		EffectType.SPEED_LINES:
 			_material.set_shader_parameter("line_color", configuration.SpeedLinesColor)
 			_material.set_shader_parameter("line_count", configuration.SpeedLinesCount)
 			_material.set_shader_parameter("line_density", configuration.SpeedLineDensity)
 			_material.set_shader_parameter("animation_speed", configuration.SpeedLineSpeed)
-		"Ascii":
+		EffectType.ASCII:
 			_material.set_shader_parameter("ascii_size", configuration.ASCIISize)
-		"CRT":
+		EffectType.CRT:
 			_material.set_shader_parameter("overlay", configuration.overlay)
 			_material.set_shader_parameter("scanlines_opacity", configuration.scanlines_opacity)
 			_material.set_shader_parameter("scanlines_width", configuration.scanlines_width)
@@ -87,86 +112,92 @@ func _update_shader_parameters( _name : String, _material : Material) -> void:
 			_material.set_shader_parameter("clip_warp", configuration.clip_warp)
 			_material.set_shader_parameter("vignette_intensity", configuration.vignette_intensity)
 			_material.set_shader_parameter("vignette_opacity", configuration.vignette_opacity)
-			
+		_:
+			push_error("Unhandled/Invalid EffectType: " + str(_type))
 
-func _check_shader_visibility(_name: String) -> bool:
-		if _name.begins_with("Palette"):
-			return true if configuration.Palette else false
-		if _name.begins_with("Pixelate"):
-			return true if configuration.Pixelate else false
-		if _name.begins_with("ColorCorrection"):
-			return true if configuration.ColorCorrection else false
-		if _name.begins_with("ChromaticAberration"):
-			return true if configuration.ChromaticAberration else false
-		
-		if _name.begins_with("Blur"):
-			return true if configuration.Blur else false
-			
-		if _name.begins_with("FishEye"):
-			return true if configuration.FishEye else false
-		
-		if _name.begins_with("Vignette"):
-			return true if configuration.Vignette else false
-		
-		if _name.begins_with("Glitch"):
-			return true if configuration.Glitch else false
-		
-		if _name.begins_with("Outline"):
-			return true if configuration.Outline else false
-		
-		if _name.begins_with("ScreenShake"):
-			return true if configuration.ScreenShake else false
-		
-		if _name.begins_with("AnalogMonitor"):
-			return true if configuration.AnalogMonitor else false
 
-		if _name.begins_with("Grain"):
-			return true if configuration.Grain else false
-		
-		if _name.begins_with("CircularWaves"):
-			return true if configuration.CircularWaves else false
-		
-		if _name.begins_with("SpeedLines"):
-			return true if configuration.SpeedLines else false
+func _check_shader_visibility(_type: EffectType) -> bool:
+	match _type:
+		EffectType.ASCII:
+			return configuration.ASCII
+		EffectType.ANALOG_MONITOR:
+			return configuration.AnalogMonitor
+		EffectType.BLUR:
+			return configuration.Blur
+		EffectType.CHROMATIC_ABERRATION:
+			return configuration.ChromaticAberration
+		EffectType.CIRCULAR_WAVES:
+			return configuration.CircularWaves
+		EffectType.COLOR_CORRECTION:
+			return configuration.ColorCorrection
+		EffectType.CRT:
+			return configuration.CRT
+		EffectType.GLITCH:
+			return configuration.Glitch
+		EffectType.GRAIN:
+			return configuration.Grain
+		EffectType.FISHEYE:
+			return configuration.FishEye
+		EffectType.OUTLINE:
+			return configuration.Outline
+		EffectType.PALETTE:
+			return configuration.Palette
+		EffectType.PIXELATE:
+			return configuration.Pixelate
+		EffectType.SCREEN_SHAKE:
+			return configuration.ScreenShake
+		EffectType.SPEED_LINES:
+			return configuration.SpeedLines
+		EffectType.VIGNETTE:
+			return configuration.Vignette
+		_:
+			push_error("Unhandled/Invalid EffectType: " + str(_type))
+			return false
 
-		if _name.begins_with("Ascii"):
-			return true if configuration.ASCII else false
-
-		if _name.begins_with("CRT"):
-			return true if configuration.CRT else false
-		# get_children() returning all _names leading Always to:
-		push_error("#Undefined type Post Processing addon - verify it has been properly integrated.")
-		return false # bad!
 
 func _ready():
-	_add_canvas_layer_children("res://addons/post_processing/node/children/ChromaticAberration.tscn", "CA")
-	_add_canvas_layer_children("res://addons/post_processing/node/children/blur.tscn", "BL")
-	_add_canvas_layer_children("res://addons/post_processing/node/children/fish_eye.tscn", "FEYE")
-	_add_canvas_layer_children("res://addons/post_processing/node/children/vignette.tscn", "VIN")
-	_add_canvas_layer_children("res://addons/post_processing/node/children/glitch.tscn", "GLI")
-	_add_canvas_layer_children("res://addons/post_processing/node/children/outline.tscn", "OUT")
-	_add_canvas_layer_children("res://addons/post_processing/node/children/screen_shake.tscn", "SCR_SHK")
-	_add_canvas_layer_children("res://addons/post_processing/node/children/analog_monitor.tscn", "ANL_MON")
-	_add_canvas_layer_children("res://addons/post_processing/node/children/grain.tscn", "GRN")
-	_add_canvas_layer_children("res://addons/post_processing/node/children/circular_waves.tscn", "CIR_WAV")
-	_add_canvas_layer_children("res://addons/post_processing/node/children/speed_lines.tscn", "SDP_LIN")
-	_add_canvas_layer_children("res://addons/post_processing/node/children/ascii.tscn", "ASCII")
-	_add_canvas_layer_children("res://addons/post_processing/node/children/CRT.tscn", "CRT")
-	_add_canvas_layer_children("res://addons/post_processing/node/children/color_correction.tscn", "CC")
-	_add_canvas_layer_children("res://addons/post_processing/node/children/pixelate.tscn", "PXL")
-	_add_canvas_layer_children("res://addons/post_processing/node/children/palette.tscn", "PLT")
+	_add_canvas_layer_children("res://addons/post_processing/node/children/ChromaticAberration.tscn", EffectType.CHROMATIC_ABERRATION)
+	_add_canvas_layer_children("res://addons/post_processing/node/children/blur.tscn", EffectType.BLUR)
+	_add_canvas_layer_children("res://addons/post_processing/node/children/fish_eye.tscn", EffectType.FISHEYE)
+	_add_canvas_layer_children("res://addons/post_processing/node/children/vignette.tscn", EffectType.VIGNETTE)
+	_add_canvas_layer_children("res://addons/post_processing/node/children/glitch.tscn", EffectType.GLITCH)
+	_add_canvas_layer_children("res://addons/post_processing/node/children/outline.tscn", EffectType.OUTLINE)
+	_add_canvas_layer_children("res://addons/post_processing/node/children/screen_shake.tscn", EffectType.SCREEN_SHAKE)
+	_add_canvas_layer_children("res://addons/post_processing/node/children/analog_monitor.tscn", EffectType.ANALOG_MONITOR)
+	_add_canvas_layer_children("res://addons/post_processing/node/children/grain.tscn", EffectType.GRAIN)
+	_add_canvas_layer_children("res://addons/post_processing/node/children/circular_waves.tscn", EffectType.CIRCULAR_WAVES)
+	_add_canvas_layer_children("res://addons/post_processing/node/children/speed_lines.tscn", EffectType.SPEED_LINES)
+	_add_canvas_layer_children("res://addons/post_processing/node/children/ascii.tscn", EffectType.ASCII)
+	_add_canvas_layer_children("res://addons/post_processing/node/children/CRT.tscn", EffectType.CRT)
+	_add_canvas_layer_children("res://addons/post_processing/node/children/color_correction.tscn", EffectType.COLOR_CORRECTION)
+	_add_canvas_layer_children("res://addons/post_processing/node/children/pixelate.tscn", EffectType.PIXELATE)
+	_add_canvas_layer_children("res://addons/post_processing/node/children/palette.tscn", EffectType.PALETTE)
+
+	var null_effects: PackedStringArray = []
+	for e in effects:
+		if (not effects.has(e)) or effects[e] == null:
+			null_effects.append(EffectType.keys()[e])
+	if not null_effects.is_empty(): # Not all effects were added
+		var null_warning = ""
+		for e in null_effects:
+			null_warning += e + " "
+		push_warning("Post process effects missing: " + null_warning)
 
 	update_shaders()
+
 
 func _enter_tree():
 	update_shaders()
 
-func _add_canvas_layer_children(_path : String, _name: String) -> void:
+
+func _add_canvas_layer_children(_path : String, _type: EffectType) -> void:
 	var child_instance = load(_path).instantiate()
 	add_child(child_instance)
-	var material_instance = child_instance.get_children()[0].material.duplicate()
-	child_instance.get_children()[0].material = material_instance
-	print_debug("Successfully added child canvas-layer: " + _name + " to PostProcess addon node.")
+	var data = child_instance.get_child(0)
+	var material_instance = data.material.duplicate()
+	data.material = material_instance
+	effects[_type] = child_instance
+
 
 func _process(delta):
 	if not configuration:


### PR DESCRIPTION
Added a dictionary to track instantiated nodes keyed to the new `EffectType` enum. Removes the need to use node names to identify which effect the node belongs to.

## Fixes
The names of the instantiated nodes seems to change during runtime resulting in the `"Undefined type Post Processing addon - verify it has been properly integrated.` error. Since we're not longer using the node names, this error message is no longer applicable and the related issues should be fixed.
- #28
- #19

## Related
- #24 